### PR TITLE
avoid incoming breakage of `for<'a> &'a T: 'a` bounds

### DIFF
--- a/snocat/src/common/protocol/negotiation.rs
+++ b/snocat/src/common/protocol/negotiation.rs
@@ -150,7 +150,7 @@ impl NegotiationClient {
   ) -> impl Future<Output = Result<S, NegotiationError<AE>>> + 'stream
   where
     S: TunnelStream + Send + 'stream,
-    for<'a> &'a mut S: TunnelStream + Send + 'a,
+    for<'a> &'a mut S: TunnelStream + Send,
   {
     const LOCAL_PROTOCOL_VERSION: u8 = 0;
     let negotiation_span = tracing::trace_span!("protocol_negotiation_client", addr=?addr);


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/98109 fixes a soundness hole in rust. Unfortunately, this fix exposes an other known bug in reasoning about bounds of the form `for<'a> &'a T: 'a`. This bug can be illustrated in the following example which is rejected since v1.0!
```rust
fn require_bound<T>()
where
    for<'a> &'a T: 'a,
    // T: 'static // <- rustc incorrectly thinks it must prove this bound for the above bound to hold.
{
}

fn test<T>() {
    require_bound::<T>();
    //^ ERROR  type parameter T doesn't live long enough
}
```

One way to work around such bug is to simply remove the bound since it is always satisfied for any type `T`.

We tried to fix this in a timely manner, but it's not a particularly easy problem. Indeed it is part of a long-term initiative under the name of "implied bounds" to better support these bounds. Sorry for any inconvenience!