### PR TITLE
Fix bound to compile with rust 1.63

### DIFF
--- a/snocat/src/common/protocol/negotiation.rs
+++ b/snocat/src/common/protocol/negotiation.rs
@@ -150,7 +150,7 @@ impl NegotiationClient {
   ) -> impl Future<Output = Result<S, NegotiationError<AE>>> + 'stream
   where
     S: TunnelStream + Send + 'stream,
-    for<'a> &'a mut S: TunnelStream + Send + 'a,
+    for<'a> &'a mut S: TunnelStream + Send,
   {
     const LOCAL_PROTOCOL_VERSION: u8 = 0;
     let negotiation_span = tracing::trace_span!("protocol_negotiation_client", addr=?addr);
@@ -238,7 +238,7 @@ where
   where
     R: 'stream,
     S: TunnelStream + Send + 'stream,
-    for<'a> &'a mut S: TunnelStream + Send + 'a,
+    for<'a> &'a mut S: TunnelStream + Send,
     TTunnel: Tunnel + 'static,
   {
     const CURRENT_PROTOCOL_VERSION: u8 = 0u8;


### PR DESCRIPTION
After upgrading to rust 1.63 this crate started failing. This change makes snocat compatible with 1.63, and it still compiles with the current toolchain specified in the project ("nightly-2022-01-24").