### PR TITLE
Added addr() implementation for pointer to TunnelIncoming

### DIFF
--- a/snocat/src/common/protocol/tunnel/mod.rs
+++ b/snocat/src/common/protocol/tunnel/mod.rs
@@ -321,6 +321,10 @@ where
   T: Deref + Send + Sync + Unpin,
   <T as Deref>::Target: TunnelUplink + Sided,
 {
+  fn addr(&self) -> TunnelAddressInfo {
+    self.deref().addr()
+  }
+
   fn open_link(&self) -> BoxFuture<'static, Result<WrappedStream, TunnelError>> {
     self.deref().open_link()
   }


### PR DESCRIPTION
TunnelInfo.addr is set in src/common/authentication/traits.perform_authentication using &tunnel.addr(), but unfortunately this returns the result of the default implementation, because the Deref type doesn't have an implementation of addr(). This PR tries to fix that.