### PR TITLE
Release/0.8.0 alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snocat"
-version = "0.8.0-alpha.5"
+version = "0.8.0-alpha.6"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "snocat-cli"
-version = "0.8.0-alpha.5"
+version = "0.8.0-alpha.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-01-18"
+channel = "nightly-2023-12-01"

--- a/snocat-cli/Cargo.toml
+++ b/snocat-cli/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "command-line-utilities"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "LICENSE*", "*.md"]
 
 [dependencies]
-snocat = { version = "^0.8.0-alpha.5", path = "../snocat" }
+snocat = { version = "^0.8.0-alpha.6", path = "../snocat" }
 anyhow = "~1.0.43"
 downcast-rs = "1.2"
 clap = "3.1"

--- a/snocat-cli/Cargo.toml
+++ b/snocat-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snocat-cli"
 description = "Streaming Network Overlay Connection Arbitration Tunnel"
-version = "0.8.0-alpha.5"
+version = "0.8.0-alpha.6"
 rust-version = "1.58.0"
 authors = ["Microsoft Corporation", "Zoey <Dessix@Dessix.net>"]
 edition = "2021"

--- a/snocat/CHANGELOG.md
+++ b/snocat/CHANGELOG.md
@@ -17,6 +17,10 @@ Upgraded Quinn to 9.3 for UDP GSO and UDP GRO support; this update broke
 several internal API assumptions and may lead to further simplifications
 around incoming connection and (bi/uni)stream handling.
 
+- Fixed pointer-based accesses to `TunnelUplink::addr()` so authentication now
+	captures the underlying tunnel's real `TunnelAddressInfo` instead of always
+	reporting `Unidentified`. (PR #7)
+
 ## [0.7.0] - 2022-10-29
 
 ### Hybrid Eventually-Consistent Tunnel Repositories (0.6.0-alpha.1)

--- a/snocat/Cargo.toml
+++ b/snocat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snocat"
 description = "Streaming Network Overlay Connection Arbitration Tunnel"
-version = "0.8.0-alpha.5"
+version = "0.8.0-alpha.6"
 rust-version = "1.63.0"
 authors = ["Microsoft Corporation", "Zoey <Dessix@Dessix.net>"]
 edition = "2021"


### PR DESCRIPTION
Creating a new alpha release
Fixed pointer-based accesses to `TunnelUplink::addr()` so authentication now
	captures the underlying tunnel's real `TunnelAddressInfo` instead of always
	reporting `Unidentified`. (PR #7)