### PR TITLE
feat: add runtime-gated QUIC connection diagnostic logging

### DIFF
--- a/snocat-cli/src/client.rs
+++ b/snocat-cli/src/client.rs
@@ -210,6 +210,11 @@ pub async fn client_main(config: ClientArgs) -> Result<()> {
   };
 
   {
+    tracing::info!(
+      driver_host = %config.driver_host,
+      driver_san = %config.driver_san,
+      "QUIC client: initiating connection to server"
+    );
     let connection = endpoint
       .connect_with(quinn_config, config.driver_host, &config.driver_san)
       .context("Connecting to server")?

--- a/snocat-cli/src/server.rs
+++ b/snocat-cli/src/server.rs
@@ -114,7 +114,23 @@ pub async fn server_main(config: self::ServerArgs) -> Result<()> {
   let quinn_config = build_quinn_config(&config)?;
   let endpoint = QuinnListenEndpoint::bind(config.quinn_bind_addr, quinn_config)?.filter_map(
     |(connecting, side)| {
-      connecting.map(move |res| res.ok().map(move |connection| (connection, side)))
+      connecting.map(move |res| match res {
+        Ok(connection) => {
+          tracing::info!(
+            remote_addr = %connection.remote_address(),
+            stable_id = connection.stable_id(),
+            "QUIC handshake completed: new connection established"
+          );
+          Some((connection, side))
+        }
+        Err(e) => {
+          tracing::warn!(
+            error = %e,
+            "QUIC handshake failed: incoming connection could not be established"
+          );
+          None
+        }
+      })
     },
   );
 

--- a/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
+++ b/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
@@ -389,7 +389,7 @@ impl TunnelUplink for QuinnTunnel {
               ),
               TunnelError::TransportError => tracing::error!(
                 tunnel_id = ?tunnel_id,
-                "QUIC outgoing stream open failed: transport error (protocol violation or version mismatch)"
+                "QUIC outgoing stream open failed: transport error (e.g., protocol violation, stateless reset, version mismatch, or other transport-level failure)"
               ),
               TunnelError::LocallyClosed => tracing::debug!(
                 tunnel_id = ?tunnel_id,

--- a/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
+++ b/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
@@ -69,6 +69,15 @@ impl QuinnTunnel {
     connection: quinn::Connection,
     side: TunnelSide,
   ) -> QuinnTunnel {
+    if crate::quic_logging::is_enabled() {
+      tracing::info!(
+        tunnel_id = ?id,
+        remote_addr = %connection.remote_address(),
+        side = ?side,
+        stable_id = connection.stable_id(),
+        "QUIC tunnel created: new connection established"
+      );
+    }
     let overall_cancellation: Arc<Dropkick<CancellationToken>> =
       Arc::new(CancellationToken::new().into());
     // Single-stream cancellations are derived from the full-cancellation token,
@@ -127,7 +136,32 @@ impl QuinnTunnel {
     .inspect_err({
       let incoming_cancellation = CancellationToken::clone(&incoming_cancellation);
       let close_reason_store = Arc::clone(&close_reason);
-      move |_tunnel_error| {
+      let tunnel_id = id;
+      move |tunnel_error| {
+        if crate::quic_logging::is_enabled() {
+          match tunnel_error {
+            TunnelError::ConnectionClosed => tracing::warn!(
+              tunnel_id = ?tunnel_id,
+              "QUIC incoming stream acceptance failed: connection closed by peer"
+            ),
+            TunnelError::ApplicationClosed => tracing::warn!(
+              tunnel_id = ?tunnel_id,
+              "QUIC incoming stream acceptance failed: application closed the connection"
+            ),
+            TunnelError::TimedOut => tracing::warn!(
+              tunnel_id = ?tunnel_id,
+              "QUIC incoming stream acceptance failed: connection idle timeout expired"
+            ),
+            TunnelError::TransportError => tracing::error!(
+              tunnel_id = ?tunnel_id,
+              "QUIC incoming stream acceptance failed: transport error (protocol violation or version mismatch)"
+            ),
+            TunnelError::LocallyClosed => tracing::debug!(
+              tunnel_id = ?tunnel_id,
+              "QUIC incoming stream acceptance stopped: connection closed locally"
+            ),
+          }
+        }
         let close_reason = TunnelCloseReason::Error(TunnelError::ConnectionClosed);
         {
           let close_reason_store = &close_reason_store;
@@ -164,6 +198,14 @@ impl TunnelControl for QuinnTunnel {
     &'a self,
     reason: TunnelCloseReason,
   ) -> BoxFuture<'a, Result<Arc<TunnelCloseReason>, Arc<TunnelCloseReason>>> {
+    if crate::quic_logging::is_enabled() {
+      tracing::info!(
+        tunnel_id = ?self.id,
+        remote_addr = %self.connection.remote_address(),
+        reason = %reason,
+        "QUIC tunnel closing"
+      );
+    }
     // Set the close reason only if it is currently [TunnelCloseReason::Unspecified]
     let prev = self.close_reason.rcu({
       let reason = Arc::new(reason);
@@ -329,7 +371,32 @@ impl TunnelUplink for QuinnTunnel {
         // until the [Tunnel], its downlink, and all its uplinks are dropped.
         let close_outgoing = self.outgoing_closed.clone();
         let close_reason_store = Arc::clone(&self.close_reason);
+        let tunnel_id = self.id;
         move |tunnel_error: &TunnelError| {
+          if crate::quic_logging::is_enabled() {
+            match tunnel_error {
+              TunnelError::ConnectionClosed => tracing::warn!(
+                tunnel_id = ?tunnel_id,
+                "QUIC outgoing stream open failed: connection closed by peer"
+              ),
+              TunnelError::ApplicationClosed => tracing::warn!(
+                tunnel_id = ?tunnel_id,
+                "QUIC outgoing stream open failed: application closed the connection"
+              ),
+              TunnelError::TimedOut => tracing::warn!(
+                tunnel_id = ?tunnel_id,
+                "QUIC outgoing stream open failed: connection idle timeout expired"
+              ),
+              TunnelError::TransportError => tracing::error!(
+                tunnel_id = ?tunnel_id,
+                "QUIC outgoing stream open failed: transport error (protocol violation or version mismatch)"
+              ),
+              TunnelError::LocallyClosed => tracing::debug!(
+                tunnel_id = ?tunnel_id,
+                "QUIC outgoing stream open stopped: connection closed locally"
+              ),
+            }
+          }
           let close_reason = TunnelCloseReason::Error(tunnel_error.clone());
           {
             let close_reason_store = &close_reason_store;
@@ -367,14 +434,71 @@ impl Tunnel for QuinnTunnel {
 
 impl From<quinn::ConnectionError> for TunnelError {
   fn from(connection_error: quinn::ConnectionError) -> Self {
+    let logging = crate::quic_logging::is_enabled();
     match connection_error {
-      quinn::ConnectionError::VersionMismatch => Self::TransportError,
-      quinn::ConnectionError::TransportError(_) => Self::TransportError,
-      quinn::ConnectionError::ConnectionClosed(_) => Self::ConnectionClosed,
-      quinn::ConnectionError::ApplicationClosed(_) => Self::ApplicationClosed,
-      quinn::ConnectionError::Reset => Self::TransportError,
-      quinn::ConnectionError::TimedOut => Self::TimedOut,
-      quinn::ConnectionError::LocallyClosed => Self::LocallyClosed,
+      quinn::ConnectionError::VersionMismatch => {
+        if logging {
+          tracing::warn!(
+            "QUIC connection dropped: version mismatch between client and server QUIC implementations"
+          );
+        }
+        Self::TransportError
+      }
+      quinn::ConnectionError::TransportError(ref e) => {
+        if logging {
+          tracing::warn!(
+            error_code = %e.code,
+            reason = %e.reason,
+            "QUIC connection dropped: transport error - {}",
+            e
+          );
+        }
+        Self::TransportError
+      }
+      quinn::ConnectionError::ConnectionClosed(ref frame) => {
+        if logging {
+          tracing::info!(
+            error_code = %frame.error_code,
+            reason = %String::from_utf8_lossy(&frame.reason),
+            "QUIC connection closed by peer"
+          );
+        }
+        Self::ConnectionClosed
+      }
+      quinn::ConnectionError::ApplicationClosed(ref frame) => {
+        if logging {
+          tracing::info!(
+            error_code = %frame.error_code,
+            reason = %String::from_utf8_lossy(&frame.reason),
+            "QUIC connection closed by application"
+          );
+        }
+        Self::ApplicationClosed
+      }
+      quinn::ConnectionError::Reset => {
+        if logging {
+          tracing::warn!(
+            "QUIC connection dropped: stateless reset received (peer may have restarted or lost state)"
+          );
+        }
+        Self::TransportError
+      }
+      quinn::ConnectionError::TimedOut => {
+        if logging {
+          tracing::warn!(
+            "QUIC connection dropped: idle timeout expired (no response from peer within timeout period)"
+          );
+        }
+        Self::TimedOut
+      }
+      quinn::ConnectionError::LocallyClosed => {
+        if logging {
+          tracing::debug!(
+            "QUIC connection closed locally"
+          );
+        }
+        Self::LocallyClosed
+      }
     }
   }
 }

--- a/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
+++ b/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
@@ -448,7 +448,7 @@ impl From<quinn::ConnectionError> for TunnelError {
         if logging {
           tracing::warn!(
             error_code = %e.code,
-            reason = %e.reason,
+            reason = %String::from_utf8_lossy(&e.reason),
             "QUIC connection dropped: transport error - {}",
             e
           );

--- a/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
+++ b/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
@@ -154,7 +154,7 @@ impl QuinnTunnel {
             ),
             TunnelError::TransportError => tracing::error!(
               tunnel_id = ?tunnel_id,
-              "QUIC incoming stream acceptance failed: transport error (protocol violation or version mismatch)"
+              "QUIC incoming stream acceptance failed: transport error (e.g., protocol violation, version mismatch, stateless reset, or other transport-level failure)"
             ),
             TunnelError::LocallyClosed => tracing::debug!(
               tunnel_id = ?tunnel_id,

--- a/snocat/src/common/tunnel_source/mod.rs
+++ b/snocat/src/common/tunnel_source/mod.rs
@@ -34,6 +34,12 @@ impl QuinnListenEndpoint {
     quinn_config: quinn::ServerConfig,
   ) -> Result<Self, std::io::Error> {
     let endpoint = quinn::Endpoint::server(quinn_config, bind_addr)?;
+    if crate::quic_logging::is_enabled() {
+      tracing::info!(
+        bind_addr = %bind_addr,
+        "QUIC listen endpoint bound successfully"
+      );
+    }
     Ok(Self {
       bind_addr,
       endpoint: Box::pin(endpoint),
@@ -63,6 +69,12 @@ where
       if self.accepting.is_some() {
         self.accepting = None;
       }
+      if crate::quic_logging::is_enabled() {
+        tracing::debug!(
+          bind_addr = %self.bind_addr,
+          "QUIC listen endpoint: already terminated, rejecting poll"
+        );
+      }
       return Poll::Ready(None);
     }
 
@@ -76,6 +88,12 @@ where
     if let Some(connecting) = futures::ready!(Future::poll(accepting.as_mut(), cx)) {
       drop(accepting);
       self.accepting = None;
+      if crate::quic_logging::is_enabled() {
+        tracing::debug!(
+          bind_addr = %self.bind_addr,
+          "QUIC listen endpoint: new incoming connection handshake initiated"
+        );
+      }
       // Here is where we'd do the check for stream subtype if we want to split on ALPN,
       // which is stored in the [Connecting::handshake_data] which is the active Session.
       // (https://docs.rs/quinn/0.9.3/quinn/struct.Connecting.html#method.handshake_data)
@@ -83,6 +101,13 @@ where
     } else {
       self.accepting = None;
       self.is_terminated = true;
+      if crate::quic_logging::is_enabled() {
+        tracing::warn!(
+          bind_addr = %self.bind_addr,
+          "QUIC listen endpoint terminated: endpoint accept returned None \
+           (socket may have been closed or encountered an unrecoverable error)"
+        );
+      }
       Poll::Ready(None)
     }
   }

--- a/snocat/src/lib.rs
+++ b/snocat/src/lib.rs
@@ -24,6 +24,7 @@
 
 pub mod common;
 pub mod ext;
+pub mod quic_logging;
 pub mod util;
 
 pub mod client;

--- a/snocat/src/quic_logging.rs
+++ b/snocat/src/quic_logging.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license OR Apache 2.0
+
+//! Runtime toggle for QUIC connection diagnostic logging.
+//!
+//! By default, QUIC connection lifecycle logging is **disabled**. Library consumers
+//! can enable it at runtime to get detailed `tracing` events for connection
+//! establishment, drops, timeouts, resets, and other QUIC-specific conditions.
+//!
+//! # Usage
+//!
+//! ```rust
+//! // Enable QUIC connection logging at application startup
+//! snocat::quic_logging::enable();
+//!
+//! // Disable it again if needed
+//! snocat::quic_logging::disable();
+//!
+//! // Check current state
+//! if snocat::quic_logging::is_enabled() {
+//!     println!("QUIC connection logging is active");
+//! }
+//! ```
+//!
+//! The emitted events use the `tracing` crate at appropriate severity levels
+//! (`error`, `warn`, `info`, `debug`) and are only generated when logging is
+//! enabled, so there is negligible overhead when disabled.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable QUIC connection diagnostic logging.
+///
+/// Once enabled, the library emits `tracing` events for QUIC connection
+/// lifecycle events such as connection creation, handshake failures,
+/// idle timeouts, transport errors, stateless resets, and graceful closures.
+pub fn enable() {
+  ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Disable QUIC connection diagnostic logging.
+pub fn disable() {
+  ENABLED.store(false, Ordering::Relaxed);
+}
+
+/// Returns `true` if QUIC connection diagnostic logging is currently enabled.
+pub fn is_enabled() -> bool {
+  ENABLED.load(Ordering::Relaxed)
+}


### PR DESCRIPTION
## Summary

Adds detailed tracing-based logging across the QUIC connection lifecycle to help diagnose connection drops. All logging is gated behind a runtime toggle so library consumers opt in explicitly.

## Motivation

QUIC connections can drop for many reasons (idle timeouts, transport errors, stateless resets, version mismatches, peer closures) but the library previously provided no diagnostic visibility into these events. Handshake failures were silently swallowed with \.ok()\.

## Changes

### New module: \snocat::quic_logging\
Runtime toggle backed by \AtomicBool\ — zero overhead when disabled:
\\\ust
snocat::quic_logging::enable();   // opt in
snocat::quic_logging::disable();  // opt out
snocat::quic_logging::is_enabled(); // check
\\\

### Logging coverage (all gated behind the toggle)

| Area | File | What's logged |
|------|------|---------------|
| **Error conversion** | \quinn_tunnel.rs\ | Each \quinn::ConnectionError\ variant logged with distinct message, structured fields (error codes, reasons) |
| **Tunnel creation** | \quinn_tunnel.rs\ | Tunnel ID, remote address, side, stable ID |
| **Incoming stream failures** | \quinn_tunnel.rs\ | \ccept_bi()\ errors with per-variant messages |
| **Outgoing stream failures** | \quinn_tunnel.rs\ | \open_bi()\ errors with per-variant messages |
| **Tunnel close** | \quinn_tunnel.rs\ | Close reason, tunnel ID, remote address |
| **Endpoint lifecycle** | \	unnel_source/mod.rs\ | Bind success, handshake initiation, termination |
| **Handshake failures** | \server.rs\ | Previously swallowed with \.ok()\, now logged |
| **Client connection** | \client.rs\ | Connection initiation to server |

### Severity levels
- \rror\ — transport errors (protocol violations)
- \warn\ — version mismatch, stateless reset, idle timeout, peer close failures
- \info\ — connection creation, graceful peer/app close, tunnel close
- \debug\ — local close, endpoint polling
