### PR TITLE
Add duration_sec and duration_ms to QUIC tunnel closing log event

### DIFF
--- a/snocat/src/common/authentication/traits.rs
+++ b/snocat/src/common/authentication/traits.rs
@@ -4,7 +4,7 @@ use crate::ext::future::TryFutureExtExt;
 #[warn(unused_imports)]
 use crate::{
   common::protocol::tunnel::{
-    Tunnel, TunnelAddressInfo, TunnelError, TunnelIncomingType, TunnelName, TunnelSide,
+    Tunnel, TunnelAddressInfo, TunnelError, TunnelId, TunnelIncomingType, TunnelName, TunnelSide,
   },
   util::{cancellation::CancellationListener, tunnel_stream::TunnelStream},
 };
@@ -18,6 +18,7 @@ use std::{
 
 #[derive(Debug, Clone)]
 pub struct TunnelInfo {
+  pub tunnel_id: TunnelId,
   pub side: TunnelSide,
   pub addr: TunnelAddressInfo,
 }
@@ -314,6 +315,7 @@ where
 {
   use tracing::{debug, debug_span, warn, Instrument};
   let tunnel_info = TunnelInfo {
+    tunnel_id: tunnel.id().clone(),
     side: tunnel.side(),
     addr: tunnel.addr(),
   };

--- a/snocat/src/common/protocol/tunnel/mod.rs
+++ b/snocat/src/common/protocol/tunnel/mod.rs
@@ -174,6 +174,16 @@ impl TunnelCloseReason {
 }
 
 pub trait TunnelMonitoring {
+  /// The instant at which this tunnel was created.
+  ///
+  /// Used to compute tunnel lifetime duration at close time.
+  /// The default returns `Instant::now()`, which will produce
+  /// inaccurate durations. Concrete tunnel implementations should
+  /// override this to return the actual creation instant.
+  fn created_at(&self) -> std::time::Instant {
+    std::time::Instant::now()
+  }
+
   /// If the tunnel is currently closed on uplink and downlink
   fn is_closed(&self) -> bool;
 

--- a/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
+++ b/snocat/src/common/protocol/tunnel/quinn_tunnel.rs
@@ -31,6 +31,7 @@ pub struct QuinnTunnel {
   connection: quinn::Connection,
   side: TunnelSide,
   incoming: Arc<tokio::sync::Mutex<TunnelIncoming>>,
+  created_at: std::time::Instant,
 
   closed: Arc<Dropkick<CancellationToken>>,
   incoming_closed: Arc<Dropkick<CancellationToken>>,
@@ -69,6 +70,7 @@ impl QuinnTunnel {
     connection: quinn::Connection,
     side: TunnelSide,
   ) -> QuinnTunnel {
+    let created_at = std::time::Instant::now();
     if crate::quic_logging::is_enabled() {
       tracing::info!(
         tunnel_id = ?id,
@@ -189,6 +191,7 @@ impl QuinnTunnel {
       outgoing_closed: Arc::new(overall_cancellation.child_token().into()),
       incoming_closed: incoming_cancellation,
       closed: overall_cancellation,
+      created_at,
     }
   }
 }
@@ -203,6 +206,7 @@ impl TunnelControl for QuinnTunnel {
         tunnel_id = ?self.id,
         remote_addr = %self.connection.remote_address(),
         reason = %reason,
+        duration_ms = self.created_at.elapsed().as_millis() as u64,
         "QUIC tunnel closing"
       );
     }
@@ -257,6 +261,10 @@ impl TunnelControl for QuinnTunnel {
 }
 
 impl TunnelMonitoring for QuinnTunnel {
+  fn created_at(&self) -> std::time::Instant {
+    self.created_at
+  }
+
   fn is_closed(&self) -> bool {
     self.closed.is_cancelled()
   }


### PR DESCRIPTION
Tracks tunnel lifetime from creation to close, emitting both seconds and milliseconds precision in the structured tracing event. 